### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The `flutter-tools` MCP server provides tools for interacting with the Flutter SDK. It offers two main tools: `get_diagnostics` and `apply_fixes`. These tools help in analyzing and fixing Dart/Flutter files.
 
+<a href="https://glama.ai/mcp/servers/4v3bx1viov"><img width="380" height="200" src="https://glama.ai/mcp/servers/4v3bx1viov/badge" alt="Flutter Tools Server MCP server" /></a>
+
 ## Tools
 
 ### get_diagnostics


### PR DESCRIPTION
This PR adds a badge for the [Flutter Tools MCP Server](https://glama.ai/mcp/servers/4v3bx1viov) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4v3bx1viov"><img width="380" height="200" src="https://glama.ai/mcp/servers/4v3bx1viov/badge" alt="Flutter Tools Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.